### PR TITLE
USB-Audio: Add Audient EVO4

### DIFF
--- a/ucm2/USB-Audio/Audient/Audient-EVO4-Hifi-0006.conf
+++ b/ucm2/USB-Audio/Audient/Audient-EVO4-Hifi-0006.conf
@@ -1,0 +1,91 @@
+Include.pcm_split.File "/common/pcm/split.conf"
+
+Macro [
+	{
+		SplitPCM {
+			Name "evo4_mono_in"
+			Direction Capture
+			Channels 1
+			HWChannels 2
+			HWChannelPos0 MONO
+			HWChannelPos1 MONO
+		}
+	}
+	{
+		SplitPCM {
+			Name "evo4_stereo_in"
+			Direction Capture
+			Channels 2
+			HWChannels 2
+			HWChannelPos0 FL
+			HWChannelPos1 FR
+		}
+	}
+]
+
+SectionDevice."Monitor" {
+	Comment "Headphones / Monitor Out"
+
+	Value {
+		PlaybackPriority 200
+		PlaybackPCM "hw:${CardId}"
+	}
+}
+
+SectionDevice."Mic1" {
+	Comment "Mic In Port 1"
+
+	Value {
+		CapturePriority 200
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "evo4_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 0
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic2" {
+	Comment "Mic In Port 2"
+
+	Value {
+		CapturePriority 100
+	}
+	Macro.pcm_split.SplitPCMDevice {
+		Name "evo4_mono_in"
+		Direction Capture
+		HWChannels 2
+		Channels 1
+		Channel0 1
+		ChannelPos0 MONO
+	}
+}
+
+SectionDevice."Mic3" {
+	Comment "Stereo Mic In 1+2"
+
+	ConflictingDevice [
+		"Mic1"
+		"Mic2"
+	]
+
+	Value {
+		CapturePriority 100
+	}
+
+	Macro.pcm_split.SplitPCMDevice {
+		Name "evo4_stereo_in"
+		Direction Capture
+		HWChannels 2
+		Channels 2
+		Channel0 0
+		Channel1 1
+		ChannelPos0 FL
+		ChannelPos1 FR
+	}
+}
+
+


### PR DESCRIPTION
**Description**

This PR is to add the Audient EVO4, which differs from id44 by providing two pre-amp Mic inputs that can optionally perform as a signal stereo input or a MIC and Line-in combo.

**Relations**

Closes #303
